### PR TITLE
Updated webpack config to remove error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Boilerplate for building RxJS applications",
   "main": "app.js",
   "scripts": {
-    "start": "live-server --port=8000"
+    "start": "webpack-dev-server --colors --progress --hot --watch"
   },
   "author": "Brad Traversy",
   "license": "ISC",
@@ -12,7 +12,8 @@
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",
-    "webpack": "^1.13.2"
+    "webpack": "^3.8.1",
+    "webpack-dev-server": "^2.9.3"
   },
   "dependencies": {
     "jquery": "^3.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	entry: './src/app.js',
 	output: {
-		path: './dist',
+		path: __dirname+'/dist',
 		filename:'app.bundle.js'
 	},
 	module: {


### PR DESCRIPTION
Hi,
I updated the `webpack` configuration file around path specification for `app.bundle.js` output. Webpack kept showing this funny cannot resolve path error.
I also had to install `webpack-dev-server` so that it can serve the project and watch it at the same time. It required updating webpack version to the latest which is cool. I also changed the start script to use webpack-dev-server.

I would have changed the README.md, but I'd just make a different PR for that one.

Hope you find this useful.