### PR TITLE
Update/readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,11 @@ Install dependencies (Webpack, Babel, RxJS 5, jQuery)
 $ npm install
 ```
 
-### Compile
-To compile all js to dist/app.bundle.js
-
-```sh
-$ webpack
-```
-To watch run
-```sh
-$ webpack -w
-```
-
 ### Run
-Install live-server globally
-```sh
-$ npm install live-server -g
-```
+RxJS Boiler will use [webpack-dev-server](https://www.npmjs.com/package/webpack-dev-server) to compile and serve this project. Just run the script to get started
 
 ```sh
 $ npm start
 ```
 
-Visit [http://localhost:8000](http://localhost:8000)
+Visit [http://localhost:8080](http://localhost:8080) or whatever link `webpack-dev-server` shows depending on if `port:8080` is available on localhost.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Boilerplate for building RxJS applications",
   "main": "app.js",
   "scripts": {
-    "start": "live-server --port=8000"
+    "start": "webpack-dev-server --colors --progress --hot --watch"
   },
   "author": "Brad Traversy",
   "license": "ISC",
@@ -12,7 +12,8 @@
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",
-    "webpack": "^1.13.2"
+    "webpack": "^3.8.1",
+    "webpack-dev-server": "^2.9.3"
   },
   "dependencies": {
     "jquery": "^3.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	entry: './src/app.js',
 	output: {
-		path: './dist',
+		path: __dirname+'/dist',
 		filename:'app.bundle.js'
 	},
 	module: {


### PR DESCRIPTION
Hi,
I made some changes to the README file to reflect my previous change to webpack config and addition of `webpack-dev-server`. So, I removed the `webpack` code as it is already deprecated. 

If you merge the previous PR, then you would can merge this as well, if not, there would be no need as everything will work fine on with the current webpack version.